### PR TITLE
Remove unused import

### DIFF
--- a/ckanext/initiatives/action.py
+++ b/ckanext/initiatives/action.py
@@ -5,7 +5,6 @@ import ckan.authz as authz
 from ckan.common import _
 from ckan.common import config
 
-from ckan.lib.base import render_jinja2
 from ckan.lib.mailer import mail_recipient
 from ckan.lib.mailer import MailerException
 import ckan.logic

--- a/ckanext/initiatives/logic.py
+++ b/ckanext/initiatives/logic.py
@@ -7,7 +7,6 @@ import ckan.authz as authz
 from ckan.common import _
 from ckan.common import config
 
-from ckan.lib.base import render_jinja2
 import ckan.lib.mailer as mailer
 import ckan.logic as logic
 import ckan.plugins.toolkit as toolkit


### PR DESCRIPTION
render_jinja2 was removed in CKAN 2.10 and was related to the old pylons code

See: https://github.com/ckan/ckan/commit/d19b2ca1bd7118068c749f773a7cd80cda8c85ef